### PR TITLE
Publish to correct nuget pkg names and folders

### DIFF
--- a/JsModels.Cmd/JsModels.Cmd.csproj
+++ b/JsModels.Cmd/JsModels.Cmd.csproj
@@ -5,13 +5,24 @@
     <OutputPath>..\build\</OutputPath>
     <AssemblyTitle>JsModels.Cmd</AssemblyTitle>
     <Product>JsModels.Cmd</Product>
-    <Copyright>Copyright ©  2015</Copyright>
+    <Copyright>Copyright © 2015</Copyright>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
+    <PackageId>JsModels.Net.Cmd</PackageId>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier> <!-- or add more RIDs as needed -->
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JsModels\JsModels.csproj" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <!-- <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" /> -->
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Include the published exe in the NuGet package under 'tools' -->
+    <None Include="publish/JsModels.Cmd.exe" Pack="true" PackagePath="content\" />
+    <!-- Include the license file -->
+    <None Include="..\LICENSE.txt" Pack="true" PackagePath="content\jsmodels-license.txt" />
   </ItemGroup>
 </Project>

--- a/JsModels.Cmd/JsModels.Cmd.csproj
+++ b/JsModels.Cmd/JsModels.Cmd.csproj
@@ -15,7 +15,7 @@
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\JsModels\JsModels.csproj" />
+    <ProjectReference Include="../JsModels/JsModels.csproj" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
   </ItemGroup>
   <ItemGroup>
@@ -23,7 +23,7 @@
       Items to be packed for publishing to NuGet
       Content in the publish folder comes from azure pipeline step, "Publish JsModels.Net.Cmd"
     -->
-    <None Include="publish/JsModels.Cmd.exe" Pack="true" PackagePath="content\" />
-    <None Include="..\LICENSE.txt" Pack="true" PackagePath="content\jsmodels-license.txt" />
+    <None Include="publish/JsModels.Cmd*" Pack="true" PackagePath="content/" />
+    <None Include="../LICENSE.txt" Pack="true" PackagePath="content/jsmodels-license.txt" />
   </ItemGroup>
 </Project>

--- a/JsModels.Cmd/JsModels.Cmd.csproj
+++ b/JsModels.Cmd/JsModels.Cmd.csproj
@@ -17,12 +17,13 @@
   <ItemGroup>
     <ProjectReference Include="..\JsModels\JsModels.csproj" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <!-- <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" /> -->
   </ItemGroup>
   <ItemGroup>
-    <!-- Include the published exe in the NuGet package under 'tools' -->
+    <!-- 
+      Items to be packed for publishing to NuGet
+      Content in the publish folder comes from azure pipeline step, "Publish JsModels.Net.Cmd"
+    -->
     <None Include="publish/JsModels.Cmd.exe" Pack="true" PackagePath="content\" />
-    <!-- Include the license file -->
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="content\jsmodels-license.txt" />
   </ItemGroup>
 </Project>

--- a/JsModels/JsModels.csproj
+++ b/JsModels/JsModels.csproj
@@ -10,6 +10,7 @@
     <Product>JsModels.Net</Product>
     <Copyright>Copyright ©  2015</Copyright>
     <AssemblyVersion>1.0.0.*</AssemblyVersion>
+    <PackageId>JsModels.Net</PackageId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Humanizer" Version="2.14.1" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,13 +32,32 @@ steps:
     arguments: '--configuration $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
-  displayName: 'Pack'
+  displayName: 'Publish JsModels.Net.Cmd'
+  inputs:
+    command: 'publish'
+    publishWebProjects: false
+    projects: 'JsModels.Cmd/JsModels.Cmd.csproj'
+    arguments: '--configuration $(buildConfiguration) --output JsModels.Cmd/publish'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Pack JsModels.Net'
   inputs:
     command: 'pack'
-    packagesToPack: '$(solution)'
+    packagesToPack: 'JsModels/JsModels.csproj'
     configuration: '$(buildConfiguration)'
     packDirectory: 'artifacts'
     versioningScheme: 'off'
+    arguments: /p:PackageVersion=$(version)
+
+- task: DotNetCoreCLI@2
+  displayName: 'Pack JsModels.Net.Cmd'
+  inputs:
+    command: 'pack'
+    packagesToPack: 'JsModels.Cmd/JsModels.Cmd.csproj'
+    configuration: '$(buildConfiguration)'
+    packDirectory: 'artifacts'
+    versioningScheme: 'off'
+    arguments: /p:PackageVersion=$(version)
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,12 +31,6 @@ steps:
     projects: '$(solution)'
     arguments: '--configuration $(buildConfiguration)'
 
-- powershell: |
-    if (Test-Path "JsModels.Cmd\publish") {
-      Remove-Item -Recurse -Force "JsModels.Cmd\publish"
-    }
-  displayName: 'Clean publish output'
-
 - task: DotNetCoreCLI@2
   displayName: 'Publish JsModels.Net.Cmd'
   inputs:
@@ -44,9 +38,6 @@ steps:
     publishWebProjects: false
     projects: 'JsModels.Cmd/JsModels.Cmd.csproj'
     arguments: '--configuration $(buildConfiguration) --output JsModels.Cmd/publish'
-
-- script: dir JsModels.Cmd\publish
-  displayName: 'List publish output'
 
 - task: DotNetCoreCLI@2
   displayName: 'Pack JsModels.Net'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,10 @@ steps:
     projects: '$(solution)'
     arguments: '--configuration $(buildConfiguration)'
 
+- script: rmdir /s /q JsModels.Cmd\publish
+  displayName: 'Clean publish output'
+  condition: exists('JsModels.Cmd\publish')
+
 - task: DotNetCoreCLI@2
   displayName: 'Publish JsModels.Net.Cmd'
   inputs:
@@ -38,6 +42,9 @@ steps:
     publishWebProjects: false
     projects: 'JsModels.Cmd/JsModels.Cmd.csproj'
     arguments: '--configuration $(buildConfiguration) --output publish'
+
+- script: dir JsModels.Cmd\publish
+  displayName: 'List publish output'
 
 - task: DotNetCoreCLI@2
   displayName: 'Pack JsModels.Net'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'JsModels.Cmd/JsModels.Cmd.csproj'
-    arguments: '--configuration $(buildConfiguration) --output JsModels.Cmd/publish'
+    arguments: '--configuration $(buildConfiguration) --output publish'
 
 - task: DotNetCoreCLI@2
   displayName: 'Pack JsModels.Net'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,9 +31,11 @@ steps:
     projects: '$(solution)'
     arguments: '--configuration $(buildConfiguration)'
 
-- script: rmdir /s /q JsModels.Cmd\publish
+- powershell: |
+    if (Test-Path "JsModels.Cmd\publish") {
+      Remove-Item -Recurse -Force "JsModels.Cmd\publish"
+    }
   displayName: 'Clean publish output'
-  condition: exists('JsModels.Cmd\publish')
 
 - task: DotNetCoreCLI@2
   displayName: 'Publish JsModels.Net.Cmd'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: 'JsModels.Cmd/JsModels.Cmd.csproj'
-    arguments: '--configuration $(buildConfiguration) --output publish'
+    arguments: '--configuration $(buildConfiguration) --output JsModels.Cmd/publish'
 
 - script: dir JsModels.Cmd\publish
   displayName: 'List publish output'


### PR DESCRIPTION
I was unable to get the self-contained exe `JsModels.Net.Cmd.exe` directly in the package's content folder. Instead the content folder has a `JsModels.Net.Cmd.zip` which contains the exe and some other assets. Copilot ran me in circles trying to solve it, but I think it's good enough.